### PR TITLE
Ensure WhatsApp icon uses absolute path

### DIFF
--- a/script.js
+++ b/script.js
@@ -542,7 +542,7 @@ function renderContactsTable(){
         wa.rel = 'noreferrer';
         wa.setAttribute('aria-label', `WhatsApp ${c.name}`);
         const img = document.createElement('img');
-        img.src = 'assets/whatsapp.svg'; // relative path to avoid subpath 404s
+        img.src = new URL('/assets/whatsapp.svg', location.origin).toString(); // resolve absolute path
         img.alt = '';
         img.width = 24; img.height = 24; img.decoding = 'async'; img.loading = 'lazy';
         img.onerror = () => { wa.textContent = 'WA'; };


### PR DESCRIPTION
## Summary
- Resolve WhatsApp icon path using `new URL` so contacts view works from any base path

## Testing
- `node <<'NODE'
const fs=require('fs'); const vm=require('vm'); let code=fs.readFileSync('script.js','utf8');
code = code.replace(/\nload\(\);\s*$/, '');
const tbody={tagName:'tbody',children:[],innerHTML:'',appendChild(child){this.children.push(child);},style:{},dataset:{}};
function element(tag){return {tagName:tag,children:[],appendChild(child){this.children.push(child);},setAttribute(name,val){this[name]=val;},style:{},dataset:{},innerHTML:'',textContent:'',width:0,height:0};}
const document={createElement:element,querySelector(sel){if(sel==='#contactsTable tbody') return tbody; return null;},body:{appendChild(){},removeChild(){}}};
const sandbox={console,location:{origin:'https://example.com'},document,URL};
vm.createContext(sandbox);
vm.runInContext(code,sandbox);
vm.runInContext("CONTACTS.contacts=[{name:'A',phone:'+1',notes:''},{name:'B',phone:'+2',notes:''}]; renderContactsTable();",sandbox);
console.log('rows',tbody.children.length);
for (const [i,row] of tbody.children.entries()) {
  const img=row.children[3].children[1].children[0];
  console.log('row',i,'img src',img.src);
}
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68a9ad40a7408327a5bd632762c16f4f