### PR TITLE
Hide phone column definition on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -502,6 +502,7 @@ img, picture, video, canvas { display:block; max-width:100%; }
   /* Hide the Phone column (2nd col) */
   #contactsTable th:nth-child(2),
   #contactsTable td:nth-child(2) { display: none; }
+  #contactsTable col.col-phone { display: none; }
 
   /* Stack names to avoid tight inline fit */
   .name-first, .name-last { display:block; }


### PR DESCRIPTION
## Summary
- hide phone `col` in contacts table for small screens to prevent blank column

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9ad41a8988327ae3cef7120e58ccf