### PR TITLE
Enlarge contact action icons and align left

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -424,15 +424,15 @@ img, picture, video, canvas { display:block; max-width:100%; }
 }
 #contactsTable .btn.icon img,
 #contactsTable .btn.icon svg {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
 }
 
 /* Actions cell layout */
 #contactsTable tbody td[data-label="Actions"] .actions {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 10px;
   flex-wrap: nowrap;
   width: 100%;
@@ -517,14 +517,14 @@ img, picture, video, canvas { display:block; max-width:100%; }
   /* Actions: compact icons only */
   #contactsTable tbody td[data-label="Actions"] .actions { gap: 8px; }
   #contactsTable .btn.icon {
-    width: 36px;
-    height: 36px;
+    width: 40px;
+    height: 40px;
     padding: 6px;
   }
   #contactsTable .btn.icon .label { display: none; }
   #contactsTable .btn.icon img,
   #contactsTable .btn.icon svg {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
   }
 }


### PR DESCRIPTION
## Summary
- Enlarge phone and WhatsApp icons in Contacts table
- Left-align action icons for clearer layout
- Scale mobile action buttons for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9c57ff7f48327a66a1b17ab8e6ab5