### PR TITLE
Scale WhatsApp icon to match call icon on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -519,12 +519,12 @@ img, picture, video, canvas { display:block; max-width:100%; }
   #contactsTable .btn.icon {
     width: 40px;
     height: 40px;
-    padding: 6px;
+    padding: 0;
   }
   #contactsTable .btn.icon .label { display: none; }
   #contactsTable .btn.icon img,
   #contactsTable .btn.icon svg {
-    width: 28px;
-    height: 28px;
+    width: 100%;
+    height: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge mobile action buttons to 40x40 with icon images filling the button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9c76b7b808327b72e45130f78c9e1