### PR TITLE
Fix spacing in contact names on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -503,7 +503,10 @@ function renderContactsTable(){
     spanLast.className = 'last';
     spanLast.textContent = last;
     tdName.appendChild(spanFirst);
-    if (last) tdName.appendChild(spanLast);
+    if (last) {
+      if (!isMobile) tdName.appendChild(document.createTextNode(' '));
+      tdName.appendChild(spanLast);
+    }
 
     // Phone column (desktop only)
     let tdPhone;


### PR DESCRIPTION
## Summary
- add desktop-only space between first and last names in contact table

## Testing
- `node --check script.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_b_68a9de59764c8327bd5fb6f4b17535ab