### PR TITLE
Add welcome message to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,14 @@
         </p>
       </header>
 
+      <div id="welcomeText" class="welcome-text">
+        <p>Welcome, dear family and friends, to our wedding week!</p>
+        <p>We feel so grateful to have you here to share such a momentous occasion with us. Thank you, truly, for making the journey to celebrate together.</p>
+        <p>Beyond the big day itself, what means the most to us is spending as much time with you as possible. To make things easy, we’ve shared our full itinerary so you’ll always know what we’re up to. You’re welcome to join in as much or as little as you like! Just let us know in advance so we can plan accordingly. If you can’t reach us directly, please connect with one of the primary contacts listed in the contacts table.</p>
+        <p>Don’t forget to check out the Explore tab for some of our favorite cafés, restaurants, and bars here in Tel Aviv.</p>
+        <p>P.S. We’re notoriously bad at remembering to take enough photos… so please help us capture the memories! Upload your shots throughout the week to our shared album: <a href="https://photos.app.goo.gl/TRPLqtHFmYZRNyb96" target="_blank" rel="noreferrer noopener">Google Photos Link</a>.</p>
+      </div>
+
       <!-- Couple photo -->
       <figure class="hero-photo">
         <img

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,17 @@ img, picture, video, canvas { display:block; max-width:100%; }
 .hero-sub   { color: var(--subtext); margin: 10px 0 0; font-weight: 500; }
 .venue-link { color: var(--subtext); text-decoration: underline; text-underline-offset: 3px; }
 
+/* Welcome text block */
+.welcome-text {
+  line-height: 1.6;
+  margin: 16px 0 24px;
+}
+.welcome-text a {
+  color: var(--blue);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 /* Couple photo */
 .hero-photo { margin: 16px -16px 32px; }
 .hero-photo img { width: 100%; height: auto; border-radius: 22px; box-shadow: var(--shadow-md); }


### PR DESCRIPTION
## Summary
- Introduce a warm multi-paragraph welcome message on the home page beneath the wedding date and venue and above the photo.
- Style welcome text for comfortable reading and clearly underline the shared photo album link.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9fa72aa108327b4bcc34ac870bd3c