### PR TITLE
fix: load itinerary assets from any path

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,9 +13,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@600;700&display=swap" rel="stylesheet">
 
-  <!-- Root-relative assets so they work at /home and /calendar -->
-  <link rel="stylesheet" href="/styles.css?v=17" />
-  <script src="/script.js" defer></script>
+  <!-- Relative assets so the site works from any path -->
+  <link rel="stylesheet" href="./styles.css?v=17" />
+  <script src="./script.js" defer></script>
 </head>
 <body>
   <!-- ===== Banner with centered countdown (pastel bloom background) ===== -->
@@ -29,10 +29,10 @@
 
   <!-- ===== Site tabs (clean paths; JS intercepts clicks) ===== -->
   <nav class="site-tabs" role="tablist" aria-label="Site sections">
-    <a href="/home" data-view="home" class="site-tab" aria-selected="true">Home</a>
-    <a href="/calendar" data-view="calendar" class="site-tab" aria-selected="false">Calendar</a>
-    <a href="/explore" data-view="explore" class="site-tab" aria-selected="false">Explore</a>
-    <a href="/contacts" data-view="contacts" class="site-tab" aria-selected="false">Contacts</a>
+    <a href="home" data-view="home" class="site-tab" aria-selected="true">Home</a>
+    <a href="calendar" data-view="calendar" class="site-tab" aria-selected="false">Calendar</a>
+    <a href="explore" data-view="explore" class="site-tab" aria-selected="false">Explore</a>
+    <a href="contacts" data-view="contacts" class="site-tab" aria-selected="false">Contacts</a>
   </nav>
 
   <!-- ===== HOME VIEW ===== -->
@@ -51,7 +51,7 @@
       <!-- Couple photo -->
       <figure class="hero-photo">
         <img
-          src="/assets/landing_page_staring_at_each_other.jpeg"
+          src="assets/landing_page_staring_at_each_other.jpeg"
           alt="Sean and Maya"
           width="1600" height="1067"
           fetchpriority="high"

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@600;700&display=swap" rel="stylesheet">
 
-  <!-- Root-relative assets so they work at /home and /calendar -->
-  <link rel="stylesheet" href="/styles.css?v=17" />
-  <script src="/script.js" defer></script>
+  <!-- Relative assets so the site works from any path -->
+  <link rel="stylesheet" href="./styles.css?v=17" />
+  <script src="./script.js" defer></script>
 </head>
 <body>
   <!-- ===== Banner with centered countdown (pastel bloom background) ===== -->
@@ -29,10 +29,10 @@
 
   <!-- ===== Site tabs (clean paths; JS intercepts clicks) ===== -->
   <nav class="site-tabs" role="tablist" aria-label="Site sections">
-    <a href="/home" data-view="home" class="site-tab" aria-selected="true">Home</a>
-    <a href="/calendar" data-view="calendar" class="site-tab" aria-selected="false">Calendar</a>
-    <a href="/explore" data-view="explore" class="site-tab" aria-selected="false">Explore</a>
-    <a href="/contacts" data-view="contacts" class="site-tab" aria-selected="false">Contacts</a>
+    <a href="home" data-view="home" class="site-tab" aria-selected="true">Home</a>
+    <a href="calendar" data-view="calendar" class="site-tab" aria-selected="false">Calendar</a>
+    <a href="explore" data-view="explore" class="site-tab" aria-selected="false">Explore</a>
+    <a href="contacts" data-view="contacts" class="site-tab" aria-selected="false">Contacts</a>
   </nav>
 
   <!-- ===== HOME VIEW ===== -->
@@ -51,7 +51,7 @@
       <!-- Couple photo -->
       <figure class="hero-photo">
         <img
-          src="/assets/landing_page_staring_at_each_other.jpeg"
+          src="assets/landing_page_staring_at_each_other.jpeg"
           alt="Sean and Maya"
           width="1600" height="1067"
           fetchpriority="high"

--- a/script.js
+++ b/script.js
@@ -5,9 +5,9 @@ const COUPLE = {
   weddingDateISO: '2025-08-31',
   venueMap: 'https://maps.app.goo.gl/njqM2sQ83jtwhUE38'
 };
-const CSV_LOCAL_PATH    = '/wedding_week_itinerary.csv'; // itinerary data
-const CSV_EXPLORE_PATH  = '/wedding_week_explore.csv';   // explore data
-const CSV_CONTACTS_PATH = '/wedding_week_contacts.csv';  // contacts & emergency data
+const CSV_LOCAL_PATH    = 'wedding_week_itinerary.csv'; // itinerary data
+const CSV_EXPLORE_PATH  = 'wedding_week_explore.csv';   // explore data
+const CSV_CONTACTS_PATH = 'wedding_week_contacts.csv';  // contacts & emergency data
 
 // ================= UTILITIES =================
 function fmtDate(iso){ try { return new Date(iso).toLocaleDateString(); } catch { return iso; } }
@@ -554,7 +554,7 @@ function renderContactsTable(){
         wa.target = '_blank';
         wa.rel = 'noreferrer';
         wa.setAttribute('aria-label', `WhatsApp ${c.name}`);
-        wa.innerHTML = '<img src="/assets/whatsapp-logo.svg" alt="" aria-hidden="true"/><span class="label">WhatsApp</span>';
+        wa.innerHTML = '<img src="assets/whatsapp-logo.svg" alt="" aria-hidden="true"/><span class="label">WhatsApp</span>';
         actionsWrap.appendChild(wa);
       }
     }
@@ -710,10 +710,10 @@ async function load(){
     }
 
     function navigate(view) {
-      let path = '/home';
-      if (view === 'calendar') path = '/calendar';
-      else if (view === 'explore') path = '/explore';
-      else if (view === 'contacts') path = '/contacts';
+      let path = 'home';
+      if (view === 'calendar') path = 'calendar';
+      else if (view === 'explore') path = 'explore';
+      else if (view === 'contacts') path = 'contacts';
       history.pushState({ view }, '', path);
       performRoute();
     }
@@ -756,9 +756,9 @@ async function load(){
       );
     }
     function navigate(view) {
-      let path = '/home';
-      if (view === 'explore') path = '/explore';
-      else if (view === 'contacts') path = '/contacts';
+      let path = 'home';
+      if (view === 'explore') path = 'explore';
+      else if (view === 'contacts') path = 'contacts';
       history.pushState({ view }, '', path);
       performRoute();
     }


### PR DESCRIPTION
## Summary
- load scripts, styles and CSVs using relative paths so calendar data appears
- navigate between tabs with relative URLs that work after refresh

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aa04ef18148327ba853cc1fe135cc4